### PR TITLE
Fix/inconsistent behaviour-1

### DIFF
--- a/packages/nextjs/components/PWANotificationHinter.tsx
+++ b/packages/nextjs/components/PWANotificationHinter.tsx
@@ -6,7 +6,7 @@ import { askForPermission, notificationsSupported, subscribeToNotifications } fr
 
 export const PWANotificationHinter = () => {
   const [isAskForPermissionLoading, setIsAskForPermissionLoading] = useState(false);
-  const [isSubscribing, setIsSubscribing] = useState(false);
+  const [isSubscribeLoading, setIsSubscribeLoading] = useState(false);
   const { setPushNotificationSubscription } = useGlobalState(state => state);
   const isClient = useIsClient();
 
@@ -46,9 +46,9 @@ export const PWANotificationHinter = () => {
   return (
     <button
       className="btn btn-primary"
-      disabled={isSubscribing}
+      disabled={isSubscribeLoading}
       onClick={async () => {
-        setIsSubscribing(true);
+        setIsSubscribeLoading(true);
         try {
           const subscription = await subscribeToNotifications();
           setPushNotificationSubscription(subscription);
@@ -58,11 +58,11 @@ export const PWANotificationHinter = () => {
           }
           setPushNotificationSubscription(null);
         } finally {
-          setIsSubscribing(false);
+          setIsSubscribeLoading(false);
         }
       }}
     >
-      {isSubscribing ? <span className="loading loading-dots loading-xs"></span> : "Subscribe to notifications"}
+      {isSubscribeLoading ? <span className="loading loading-dots loading-xs"></span> : "Subscribe to notifications"}
     </button>
   );
 };

--- a/packages/nextjs/components/PWANotificationHinter.tsx
+++ b/packages/nextjs/components/PWANotificationHinter.tsx
@@ -2,21 +2,55 @@ import { useState } from "react";
 import { useIsClient } from "usehooks-ts";
 import { useGlobalState } from "~~/services/store/store";
 import { notification } from "~~/utils/scaffold-eth";
-import { notificationsSupported, subscribe } from "~~/utils/service-workers";
+import { askForPermission, notificationsSupported, subscribeToNotifications } from "~~/utils/service-workers";
 
 export const PWANotificationHinter = () => {
-  const [isLoading, setIsLoading] = useState(false);
+  const [isAskForPermissionLoading, setIsAskForPermissionLoading] = useState(false);
+  const [isSubscribing, setIsSubscribing] = useState(false);
   const { setPushNotificationSubscription } = useGlobalState(state => state);
   const isClient = useIsClient();
 
-  return isClient ? (
+  if (!isClient || !window) return null;
+
+  if (!notificationsSupported()) {
+    return (
+      <button className="btn btn-primary" disabled={true}>
+        Please install PWA first
+      </button>
+    );
+  }
+
+  if (window.Notification.permission !== "granted") {
+    return (
+      <button
+        className="btn btn-primary"
+        disabled={isAskForPermissionLoading}
+        onClick={async () => {
+          try {
+            setIsAskForPermissionLoading(true);
+            await askForPermission();
+          } catch (e) {
+            if (e instanceof Error) {
+              notification.error(e.message);
+            }
+          } finally {
+            setIsAskForPermissionLoading(false);
+          }
+        }}
+      >
+        {isAskForPermissionLoading ? <span className="loading loading-dots loading-xs"></span> : "Allow Notifications"}
+      </button>
+    );
+  }
+
+  return (
     <button
       className="btn btn-primary"
-      disabled={!notificationsSupported()}
+      disabled={isSubscribing}
       onClick={async () => {
+        setIsSubscribing(true);
         try {
-          setIsLoading(true);
-          const subscription = await subscribe();
+          const subscription = await subscribeToNotifications();
           setPushNotificationSubscription(subscription);
         } catch (e) {
           if (e instanceof Error) {
@@ -24,17 +58,11 @@ export const PWANotificationHinter = () => {
           }
           setPushNotificationSubscription(null);
         } finally {
-          setIsLoading(false);
+          setIsSubscribing(false);
         }
       }}
     >
-      {isLoading ? (
-        <span className="loading loading-dots loading-xs"></span>
-      ) : notificationsSupported() ? (
-        "Allow Notifications"
-      ) : (
-        "Please install PWA first"
-      )}
+      {isSubscribing ? <span className="loading loading-dots loading-xs"></span> : "Subscribe to notifications"}
     </button>
-  ) : null;
+  );
 };

--- a/packages/nextjs/database/firebase/utils.ts
+++ b/packages/nextjs/database/firebase/utils.ts
@@ -9,7 +9,7 @@ type Subscription = {
 
 const subscriptionCollectionRef = collection(firebaseDB, COLLECTION_NAME);
 
-export const saveSubscriptionToDb = async (subscription: PushSubscription) => {
+export const saveSubscriptionInDb = async (subscription: PushSubscription) => {
   try {
     await addDoc(subscriptionCollectionRef, subscription);
   } catch (e) {
@@ -32,7 +32,7 @@ export const getAllSubsriptionsFromDb = async () => {
   }
 };
 
-export const isMySubscriptionPresent = async (subscription: PushSubscription) => {
+export const isSubscriptionPresentInDB = async (subscription: PushSubscription) => {
   try {
     const q = query(subscriptionCollectionRef, where("endpoint", "==", subscription.endpoint));
     const querySnapshot = await getDocs(q);
@@ -42,7 +42,7 @@ export const isMySubscriptionPresent = async (subscription: PushSubscription) =>
   }
 };
 
-export const deleteSubscriptionFromDatabase = async (subscription: PushSubscription) => {
+export const deleteSubscriptionFromDB = async (subscription: PushSubscription) => {
   try {
     const q = query(subscriptionCollectionRef, where("endpoint", "==", subscription.endpoint));
     const querySnapshot = await getDocs(q);

--- a/packages/nextjs/database/firebase/utils.ts
+++ b/packages/nextjs/database/firebase/utils.ts
@@ -1,5 +1,5 @@
 import { COLLECTION_NAME, firebaseDB } from "./config";
-import { addDoc, collection, deleteDoc, getDocs } from "firebase/firestore";
+import { addDoc, collection, deleteDoc, getDocs, query, where } from "firebase/firestore";
 import { PushSubscription } from "web-push";
 
 type Subscription = {
@@ -32,15 +32,23 @@ export const getAllSubsriptionsFromDb = async () => {
   }
 };
 
-export const deleteSubscriptionFromDatabase = async (id: string) => {
+export const isMySubscriptionPresent = async (subscription: PushSubscription) => {
   try {
-    const querySnapshot = await getDocs(subscriptionCollectionRef);
-    console.log("The id is", id);
+    const q = query(subscriptionCollectionRef, where("endpoint", "==", subscription.endpoint));
+    const querySnapshot = await getDocs(q);
+    return !querySnapshot.empty;
+  } catch (e) {
+    console.log("Error while fetching from DB :", e);
+  }
+};
+
+export const deleteSubscriptionFromDatabase = async (subscription: PushSubscription) => {
+  try {
+    const q = query(subscriptionCollectionRef, where("endpoint", "==", subscription.endpoint));
+    const querySnapshot = await getDocs(q);
 
     querySnapshot.forEach(async doc => {
-      if (doc.ref.id === id) {
-        await deleteDoc(doc.ref);
-      }
+      await deleteDoc(doc.ref);
     });
   } catch (e) {
     console.log("Error while deleting from DB :", e);

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -14,7 +14,7 @@ import { useGlobalState } from "~~/services/store/store";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { appChains } from "~~/services/web3/wagmiConnectors";
 import "~~/styles/globals.css";
-import { checkMySubscriptionInDB } from "~~/utils/push-api-calls";
+import { checkMySubscription } from "~~/utils/push-api-calls";
 
 const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
   const price = useNativeCurrencyPrice();
@@ -43,7 +43,7 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
           setPushNotificationSubscription(null);
           return;
         }
-        const data = await checkMySubscriptionInDB(subscription);
+        const data = await checkMySubscription(subscription);
 
         if (!data.isPresent) {
           await subscription.unsubscribe();

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -14,6 +14,7 @@ import { useGlobalState } from "~~/services/store/store";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { appChains } from "~~/services/web3/wagmiConnectors";
 import "~~/styles/globals.css";
+import { checkMySubscriptionInDB } from "~~/utils/push-api-calls";
 
 const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
   const price = useNativeCurrencyPrice();
@@ -34,11 +35,28 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
 
   useEffect(() => {
     async function getSubscription() {
+      let subscription: PushSubscription | null = null;
       try {
         const swRegistration = await navigator.serviceWorker.ready;
-        const subscription = await swRegistration.pushManager.getSubscription();
+        subscription = await swRegistration.pushManager.getSubscription();
+        if (!subscription) {
+          setPushNotificationSubscription(null);
+          return;
+        }
+        const data = await checkMySubscriptionInDB(subscription);
+
+        if (!data.isPresent) {
+          await subscription.unsubscribe();
+          setPushNotificationSubscription(null);
+          return;
+        }
         setPushNotificationSubscription(subscription);
+        console.log("subscription is:", subscription);
       } catch (e) {
+        if (subscription) {
+          await subscription.unsubscribe();
+        }
+        setPushNotificationSubscription(null);
         console.log(e);
       }
     }

--- a/packages/nextjs/pages/api/push/add-subscription.ts
+++ b/packages/nextjs/pages/api/push/add-subscription.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import webpush, { PushSubscription } from "web-push";
-import { saveSubscriptionToDb } from "~~/database/firebase/utils";
+import { saveSubscriptionInDb } from "~~/database/firebase/utils";
 
 const PUBLIC_KEY_VAPID = process.env.NEXT_PUBLIC_PUBLIC_KEY_VAPID ?? "";
 const PRIVATE_KEY_VAPID = process.env.PRIVATE_KEY_VAPID ?? "";
@@ -27,7 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const subscription = req.body as PushSubscription;
 
   try {
-    await saveSubscriptionToDb(subscription);
+    await saveSubscriptionInDb(subscription);
     res.status(200).json({ message: "Subscription added." });
   } catch (e) {
     console.log("Error :", e);

--- a/packages/nextjs/pages/api/push/checkIsSubscriptionPresent.ts
+++ b/packages/nextjs/pages/api/push/checkIsSubscriptionPresent.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import webpush, { PushSubscription } from "web-push";
-import { isMySubscriptionPresent } from "~~/database/firebase/utils";
+import { isSubscriptionPresentInDB } from "~~/database/firebase/utils";
 
 const PUBLIC_KEY_VAPID = process.env.NEXT_PUBLIC_PUBLIC_KEY_VAPID ?? "";
 const PRIVATE_KEY_VAPID = process.env.PRIVATE_KEY_VAPID ?? "";
@@ -28,7 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const subscription = req.body as PushSubscription;
 
   try {
-    const isPresent = await isMySubscriptionPresent(subscription);
+    const isPresent = await isSubscriptionPresentInDB(subscription);
     res.status(200).json({ isPresent });
   } catch (e) {
     console.log("Error :", e);

--- a/packages/nextjs/pages/api/push/checkMySubscription.ts
+++ b/packages/nextjs/pages/api/push/checkMySubscription.ts
@@ -1,0 +1,47 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import webpush, { PushSubscription } from "web-push";
+import { isMySubscriptionPresent } from "~~/database/firebase/utils";
+
+const PUBLIC_KEY_VAPID = process.env.NEXT_PUBLIC_PUBLIC_KEY_VAPID ?? "";
+const PRIVATE_KEY_VAPID = process.env.PRIVATE_KEY_VAPID ?? "";
+webpush.setVapidDetails("mailto:admin@buidlguidl.com", PUBLIC_KEY_VAPID, PRIVATE_KEY_VAPID);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!req.body || !req.body.endpoint) {
+    // Not a valid subscription.
+    res.status(400);
+    res.setHeader("Content-Type", "application/json");
+    res.send(
+      JSON.stringify({
+        isPresent: false,
+        error: {
+          id: "no-endpoint",
+          message: "Subscription must have an endpoint.",
+        },
+      }),
+    );
+    return res;
+  }
+  const subscription = req.body as PushSubscription;
+
+  try {
+    const isPresent = await isMySubscriptionPresent(subscription);
+    res.status(200).json({ isPresent });
+  } catch (e) {
+    console.log("Error :", e);
+    res.status(500);
+    res.setHeader("Content-Type", "application/json");
+    res.send(
+      JSON.stringify({
+        isPresent: false,
+        error: {
+          id: "unable-to-save-subscription",
+          message: "The subscription was received but we were unable to save it to our database.",
+        },
+      }),
+    );
+  }
+}

--- a/packages/nextjs/pages/api/push/deleteSubscription.ts
+++ b/packages/nextjs/pages/api/push/deleteSubscription.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { PushSubscription } from "web-push";
-import { deleteSubscriptionFromDatabase } from "~~/database/firebase/utils";
+import { deleteSubscriptionFromDB } from "~~/database/firebase/utils";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -22,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   const subscription = req.body as PushSubscription;
   try {
-    await deleteSubscriptionFromDatabase(subscription);
+    await deleteSubscriptionFromDB(subscription);
     res.status(200).json({ message: "Subscription deleted" });
   } catch (e) {
     console.log("Error :", e);

--- a/packages/nextjs/pages/api/push/deleteSubscription.ts
+++ b/packages/nextjs/pages/api/push/deleteSubscription.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { PushSubscription } from "web-push";
+import { deleteSubscriptionFromDatabase } from "~~/database/firebase/utils";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!req.body || !req.body.endpoint) {
+    // Not a valid subscription.
+    res.status(400);
+    res.setHeader("Content-Type", "application/json");
+    res.send(
+      JSON.stringify({
+        error: {
+          id: "no-endpoint",
+          message: "Subscription must have an endpoint.",
+        },
+      }),
+    );
+    return res;
+  }
+  const subscription = req.body as PushSubscription;
+  try {
+    await deleteSubscriptionFromDatabase(subscription);
+    res.status(200).json({ message: "Subscription deleted" });
+  } catch (e) {
+    console.log("Error :", e);
+    res.status(500);
+    res.setHeader("Content-Type", "application/json");
+    res.send(
+      JSON.stringify({
+        error: {
+          id: "unable-to-delete-subscription",
+          message: "The subscription was received but we were unable to delete it to our database.",
+        },
+      }),
+    );
+  }
+}

--- a/packages/nextjs/pages/api/push/notify-all.ts
+++ b/packages/nextjs/pages/api/push/notify-all.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import webpush, { PushSubscription } from "web-push";
-import { deleteSubscriptionFromDatabase, getAllSubsriptionsFromDb } from "~~/database/firebase/utils";
+import { deleteSubscriptionFromDB, getAllSubsriptionsFromDb } from "~~/database/firebase/utils";
 
 type Subscription = {
   _id: string;
@@ -13,7 +13,7 @@ const triggerPush = async (subscription: Subscription, dataToSend: string) => {
   } catch (err: any) {
     if (err.statusCode === 410 || err.statusCode === 404) {
       console.log("Subscription has expired or is no longer valid: ", subscription._id);
-      await deleteSubscriptionFromDatabase(subscription.pushSubscription);
+      await deleteSubscriptionFromDB(subscription.pushSubscription);
     } else {
       console.log("Subscription is no longer valid: ", err);
       throw err;

--- a/packages/nextjs/pages/api/push/notify-all.ts
+++ b/packages/nextjs/pages/api/push/notify-all.ts
@@ -13,7 +13,7 @@ const triggerPush = async (subscription: Subscription, dataToSend: string) => {
   } catch (err: any) {
     if (err.statusCode === 410 || err.statusCode === 404) {
       console.log("Subscription has expired or is no longer valid: ", subscription._id);
-      await deleteSubscriptionFromDatabase(subscription._id);
+      await deleteSubscriptionFromDatabase(subscription.pushSubscription);
     } else {
       console.log("Subscription is no longer valid: ", err);
       throw err;

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -3,35 +3,42 @@ import type { NextPage } from "next";
 import { MetaHeader } from "~~/components/MetaHeader";
 import { PWANotificationHinter } from "~~/components/PWANotificationHinter";
 import { useGlobalState } from "~~/services/store/store";
+import { deleteMySubscriptionInDB, notifyAllSubscribers } from "~~/utils/push-api-calls";
 import { notification } from "~~/utils/scaffold-eth";
 
 const Home: NextPage = () => {
   const [sendingNotication, setSendingNotifaction] = useState(false);
-  const pushNotificationSubscription = useGlobalState(state => state.pushNotificationSubscription);
+  const [unsubscribing, setUnsubscribing] = useState(false);
+  const { pushNotificationSubscription, setPushNotificationSubscription } = useGlobalState(state => state);
 
   const notifAll = async () => {
     setSendingNotifaction(true);
     try {
-      const res = await fetch("/api/push/notify-all", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          message: "This is a test notification",
-        }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        throw new Error(data.message);
-      }
-
-      console.log("Response", data);
+      await notifyAllSubscribers("This is test notification from Scaffold-ETH 2 PWA");
     } catch (err) {
       if (err instanceof Error) notification.error(err.message);
       console.log(err);
     } finally {
       setSendingNotifaction(false);
+    }
+  };
+
+  const unsubscribeMe = async () => {
+    setUnsubscribing(true);
+    try {
+      const swRegistration = await navigator.serviceWorker.ready;
+      const subscription = await swRegistration.pushManager.getSubscription();
+      if (!subscription) {
+        setPushNotificationSubscription(null);
+        return;
+      }
+      await deleteMySubscriptionInDB(subscription);
+      await subscription?.unsubscribe();
+      setPushNotificationSubscription(null);
+    } catch {
+      notification.error("Failed to unsubscribe");
+    } finally {
+      setUnsubscribing(false);
     }
   };
 
@@ -45,9 +52,14 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Scaffold-ETH 2 PWA 📱</span>
           </h1>
           {pushNotificationSubscription ? (
-            <button onClick={notifAll} className="btn btn-primary" disabled={sendingNotication}>
-              {sendingNotication ? <span className="loading loading-dots loading-xs"></span> : "Notify All"}
-            </button>
+            <div className="flex flex-col gap-4">
+              <button onClick={notifAll} className="btn btn-primary" disabled={sendingNotication || unsubscribing}>
+                {sendingNotication ? <span className="loading loading-dots loading-xs"></span> : "Notify All"}
+              </button>
+              <button className="btn btn-primary" disabled={sendingNotication || unsubscribing} onClick={unsubscribeMe}>
+                {unsubscribing ? <span className="loading loading-dots loading-xs"></span> : "Unsubscribe Me"}
+              </button>
+            </div>
           ) : (
             <PWANotificationHinter />
           )}

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -3,7 +3,7 @@ import type { NextPage } from "next";
 import { MetaHeader } from "~~/components/MetaHeader";
 import { PWANotificationHinter } from "~~/components/PWANotificationHinter";
 import { useGlobalState } from "~~/services/store/store";
-import { deleteMySubscriptionInDB, notifyAllSubscribers } from "~~/utils/push-api-calls";
+import { deleteSubscription, notifyAllSubscribers } from "~~/utils/push-api-calls";
 import { notification } from "~~/utils/scaffold-eth";
 
 const Home: NextPage = () => {
@@ -32,7 +32,7 @@ const Home: NextPage = () => {
         setPushNotificationSubscription(null);
         return;
       }
-      await deleteMySubscriptionInDB(subscription);
+      await deleteSubscription(subscription);
       await subscription?.unsubscribe();
       setPushNotificationSubscription(null);
     } catch {

--- a/packages/nextjs/utils/push-api-calls/index.ts
+++ b/packages/nextjs/utils/push-api-calls/index.ts
@@ -15,8 +15,8 @@ export const notifyAllSubscribers = async (message: string) => {
   console.log("Response", data);
 };
 
-export const checkMySubscriptionInDB = async (subscription: PushSubscription) => {
-  const res = await fetch("/api/push/checkMySubscription", {
+export const checkMySubscription = async (subscription: PushSubscription) => {
+  const res = await fetch("/api/push/checkIsSubscriptionPresent", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -31,7 +31,7 @@ export const checkMySubscriptionInDB = async (subscription: PushSubscription) =>
   return data;
 };
 
-export const deleteMySubscriptionInDB = async (subscription: PushSubscription) => {
+export const deleteSubscription = async (subscription: PushSubscription) => {
   const res = await fetch("/api/push/deleteSubscription", {
     method: "POST",
     headers: {
@@ -47,7 +47,7 @@ export const deleteMySubscriptionInDB = async (subscription: PushSubscription) =
   return data;
 };
 
-export const saveSubscriptionInDB = async (subscription: PushSubscription) => {
+export const saveSubscription = async (subscription: PushSubscription) => {
   const ORIGIN = window.location.origin;
   const BACKEND_URL = `${ORIGIN}/api/push/add-subscription`;
 

--- a/packages/nextjs/utils/push-api-calls/index.ts
+++ b/packages/nextjs/utils/push-api-calls/index.ts
@@ -46,3 +46,18 @@ export const deleteMySubscriptionInDB = async (subscription: PushSubscription) =
   console.log("Response", data);
   return data;
 };
+
+export const saveSubscriptionInDB = async (subscription: PushSubscription) => {
+  const ORIGIN = window.location.origin;
+  const BACKEND_URL = `${ORIGIN}/api/push/add-subscription`;
+
+  const response = await fetch(BACKEND_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(subscription),
+  });
+  console.log("Sever Response", response);
+  return response.json();
+};

--- a/packages/nextjs/utils/push-api-calls/index.ts
+++ b/packages/nextjs/utils/push-api-calls/index.ts
@@ -1,0 +1,48 @@
+export const notifyAllSubscribers = async (message: string) => {
+  const res = await fetch("/api/push/notify-all", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      message,
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.message);
+  }
+  console.log("Response", data);
+};
+
+export const checkMySubscriptionInDB = async (subscription: PushSubscription) => {
+  const res = await fetch("/api/push/checkMySubscription", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(subscription),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.message);
+  }
+  console.log("Response", data);
+  return data;
+};
+
+export const deleteMySubscriptionInDB = async (subscription: PushSubscription) => {
+  const res = await fetch("/api/push/deleteSubscription", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(subscription),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.message);
+  }
+  console.log("Response", data);
+  return data;
+};

--- a/packages/nextjs/utils/service-workers/index.ts
+++ b/packages/nextjs/utils/service-workers/index.ts
@@ -1,4 +1,4 @@
-import { saveSubscriptionInDB } from "../push-api-calls";
+import { saveSubscription } from "../push-api-calls";
 import { notification } from "../scaffold-eth";
 
 export const notificationsSupported = () => {
@@ -43,7 +43,7 @@ export const subscribeToNotifications = async () => {
       userVisibleOnly: true,
     };
     const subscription = await swRegistration.pushManager.subscribe(options);
-    await saveSubscriptionInDB(subscription);
+    await saveSubscription(subscription);
     notification.remove(notificationId);
     notification.success("Successfully subscribed to notifications");
     return subscription;

--- a/packages/nextjs/utils/service-workers/index.ts
+++ b/packages/nextjs/utils/service-workers/index.ts
@@ -29,7 +29,7 @@ export const subscribeToNotifications = async () => {
     await navigator.serviceWorker.ready;
     notification.remove(notificationId);
 
-    notificationId = notification.loading("Subscribing to notifications");
+    notificationId = notification.loading("Subscribing to notification");
     const swRegistration = await navigator.serviceWorker.getRegistration("/sw.js");
     if (!swRegistration) {
       throw new Error("Not Registered");
@@ -45,7 +45,7 @@ export const subscribeToNotifications = async () => {
     const subscription = await swRegistration.pushManager.subscribe(options);
     await saveSubscription(subscription);
     notification.remove(notificationId);
-    notification.success("Successfully subscribed to notifications");
+    notification.success("Successfully subscribed to notification");
     return subscription;
   } catch (err: any) {
     if (err instanceof Error) {

--- a/packages/nextjs/utils/service-workers/index.ts
+++ b/packages/nextjs/utils/service-workers/index.ts
@@ -47,13 +47,15 @@ export const subscribeToNotifications = async () => {
     notification.remove(notificationId);
     notification.success("Successfully subscribed to notifications");
     return subscription;
-  } catch (err) {
+  } catch (err: any) {
     if (err instanceof Error) {
       switch (err.message) {
         case "Not Registered":
           throw new Error("Service Worker not registered, please try again later");
         case "ServiceWorker Installing":
           throw new Error("Service Worker is installing, please try again");
+        default:
+          throw new Error(`Error while subscribing to notifications ${err?.message}`);
       }
     }
     console.error("Inside subscribe function: ", err);

--- a/packages/nextjs/utils/service-workers/index.ts
+++ b/packages/nextjs/utils/service-workers/index.ts
@@ -1,3 +1,6 @@
+import { saveSubscriptionInDB } from "../push-api-calls";
+import { notification } from "../scaffold-eth";
+
 export const notificationsSupported = () => {
   if (typeof window === undefined) return false;
 
@@ -9,41 +12,55 @@ export const unregisterServiceWorkers = async () => {
   await Promise.all(registrations.map(r => r.unregister()));
 };
 
-export const subscribe = async () => {
+export const askForPermission = async () => {
   try {
-    const swRegistration = await navigator.serviceWorker.getRegistration("/sw.js");
     const premissionResult = await window?.Notification.requestPermission();
     if (premissionResult === "denied") alert("Permission already denied, please enable notifications manually");
+  } catch (err) {
+    console.error("Inside askForPermission function: ", err);
+    throw new Error(`Error while allowing for notifications`);
+  }
+};
+
+export const subscribeToNotifications = async () => {
+  let notificationId = null;
+  try {
+    notificationId = notification.loading("Waiting for serviceWorker");
+    await navigator.serviceWorker.ready;
+    notification.remove(notificationId);
+
+    notificationId = notification.loading("Subscribing to notifications");
+    const swRegistration = await navigator.serviceWorker.getRegistration("/sw.js");
     if (!swRegistration) {
-      throw new Error("Service worker not registered");
+      throw new Error("Not Registered");
     }
 
+    if (swRegistration.installing) {
+      throw new Error("ServiceWorker Installing");
+    }
     const options = {
       applicationServerKey: process.env.NEXT_PUBLIC_PUBLIC_KEY_VAPID ?? "",
       userVisibleOnly: true,
     };
     const subscription = await swRegistration.pushManager.subscribe(options);
-
-    await saveSubscription(subscription);
-
+    await saveSubscriptionInDB(subscription);
+    notification.remove(notificationId);
+    notification.success("Successfully subscribed to notifications");
     return subscription;
   } catch (err) {
+    if (err instanceof Error) {
+      switch (err.message) {
+        case "Not Registered":
+          throw new Error("Service Worker not registered, please try again later");
+        case "ServiceWorker Installing":
+          throw new Error("Service Worker is installing, please try again");
+      }
+    }
     console.error("Inside subscribe function: ", err);
-    throw new Error("Error while subscribing to push notifications");
+    throw new Error(`Error while subscribing to notifications`);
+  } finally {
+    if (notificationId) {
+      notification.remove(notificationId);
+    }
   }
-};
-
-const saveSubscription = async (subscription: PushSubscription) => {
-  const ORIGIN = window.location.origin;
-  const BACKEND_URL = `${ORIGIN}/api/push/add-subscription`;
-
-  const response = await fetch(BACKEND_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(subscription),
-  });
-  console.log("Sever Response", response);
-  return response.json();
 };


### PR DESCRIPTION
## Description

I have been testing it and researching about inconsistency we got in #3 & #2, really tried hard to get the entropy to a minimum in this PR but there are few things kind of not in our hand (will mention about it later) 

A couple of things to keep in mind : 

1. Creating a new Firestore requires generating new VAPID keys
2. We shouldn't forget to set firestore rules properly
3. Updating env's properly 😅
4. when deploying to vercel, updating env's there too


## Tries to handle #2 & #3 

### States #2 issue

Actually, I was having hard time syncing up states between 3 things : 
1. Service Worker(SW) push subscription
2. Our Next app state 
3. state in firestore DB 

Reason 1. and 2. are different because service worker runs on its own thread, it activation and termination are controlled by the browser. We can updated pieces of SW from our app but vice versa is hard

And example case while testing : 

1. You allow notification, this registers Push subscription with your SW and also update firestore DB with that subscription
2. The user manually deletes that subscription from DB 

Now you have a subscription in SW therefore we were showing "Notify All" button and when clicked nothing happens since server is not able to find this subscription and push notification 

**Solution**: I tried solving this by as soon as our app loads in `_app.tsx`  I check if SW has subscription if yes, make a request to DB  to check if it's present their and if it's not present I remove it from SW too and user needs to resubscribe for notification. 

And also tried separating a few pieces because it was causing confusion, here is the new flow : 

1. You see "Allow notifcation" which just ask for permission that's it 
2. You need to click "Subscribe to notifcation"  this registers subscription with SW and stores it in DB 
3. "Notify All" sends Push notification to all the subscriptions 
5. there is also "Unsubscribe me" btn which remove subscription from both SW and DB 

which hopefully solves most of the things from Pablo's https://github.com/BuidlGuidl/PWA-burner-wallet/issues/2#issuecomment-1748614593

> - **Special cases:**
>        - When you delete notification permissions, it does not actually remove the subscription page on Firestore until you hit the *"Notify all"* button to send a new notification. By doing that, the log shows `4 messages sent`, but then removes the old one, and you don't get an error on that one, so I guess is before actually pushing the notification.

Yeah, actually I have a fallback setup in server while pushing notification that if we are not able to send notification to particular subscription and we get (410 or 404 [push status code](https://pushpad.xyz/blog/web-push-errors-explained-with-http-status-codes#:~:text=404%20Not%20Found%3A%20the%20endpoint,push%20notifications%20from%20browser%20settings))) since it will be expired or user have removed persmission. We remove it from DB. 

> - When I stop the app in my bash console, , and yarn start again, somtimes I get the I receive 500 Internal Server Error and sometimes I get directly the {"code":401,"errno":109,"error":"Unauthorized","message":"Missing VAPID public key".

This is really strange 😅 could you please send SS of your bash console when this happens 🙌

Since we are not able to listen user manually disabling notification (which he can also do it while app is close ) so we have to use the above method.


### Mobile problems #3 

Actually on mobile devices SW takes a bit more time to get loaded and be ready as compared to desktop due to its processing limitation  (this [google's web dev article](https://web.dev/navigation-preload/#the-problem) nicely talks about it) especially if it's you very very first time visitng that domain. 

And previously I was not properly waiting for SW to get ready and loaded properly that's why we faced the problem in #3 where initially it throws you error and after few tries / reload (when SW is registerd ) its ready to notify 

Solution: Used this api `await navigator.serviceWorker.ready;` so that we wait for SW get properly loaded and be ready will add a GH comment on code more about it. 

Now it's working nicely on mobile every time I try 



---

Lastly, I really agree that there is kind of still a bit of randomness but its also because since there are a lot of async factors involved that we can't handle for eg : 

If the user has turned on Battery optimization and doing another heavy task on another app then the browser will put some SW to sleep and at that time user won't receive the notification (lol the eg I took from an article) or maybe there is some [permission](https://frizbit.com/blog/troubleshooting-web-push-notifications-why-im-i-not-getting-notifications/#wcd_ww) problem from users side 

But yeah we could optimize some stuff moving forward 🙌
