### PR TITLE
Add explanation on how to refresh Vercel environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can do this in the Vercel Project dashboard under _"Settings > Environment V
 
 > Hint: You can mass copy all the config variables from your `packages/nextjs/.env.local` config files and paste them into the Vercel form.
 
-> Note: If you run `yarn vercel` from the CLI, after setting all environment variables in Vercel, you will need to perform a second deployment to refresh them, by running `yarn vercel` again.
+After setting all the environment variables, **you will need to perform a new deployment to refresh them**. You can do it through the Vercel UI at _"Deployments > Redeploy"_ or by running `yarn vercel` again.
 
 ## Development and References
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ You can do this in the Vercel Project dashboard under _"Settings > Environment V
 
 > Hint: You can mass copy all the config variables from your `packages/nextjs/.env.local` config files and paste them into the Vercel form.
 
+> Note: If you run `yarn vercel` from the CLI, after setting all environment variables in Vercel, you will need to perform a second deployment to refresh them, by running `yarn vercel` again.
+
 ## Development and References
 
 ### Important Development files


### PR DESCRIPTION
Adding extra explanations to the README on how to refresh Vercel env. variables when you run `yarn vercel` from CLI, and then set the variables in Vercel Project Dashboard. 

In that case variables don't get refreshed (hence push notifications don't work) until you run a second deployment (same would apply when you change your keys for some reason, you'd need to run a new deployment).

See: https://github.com/BuidlGuidl/PWA-burner-wallet/issues/3#issuecomment-1751493977